### PR TITLE
Rename carrier to airline

### DIFF
--- a/ac_aqd/airlines/__init__.py
+++ b/ac_aqd/airlines/__init__.py
@@ -1,0 +1,8 @@
+from .ac import AirCanada
+from .base import Airline
+
+
+AIRLINES = (AirCanada,)
+
+
+DEFAULT_AIRLINE, DEFAULT_AIRLINE_INDEX = AirCanada, 0

--- a/ac_aqd/airlines/ac.py
+++ b/ac_aqd/airlines/ac.py
@@ -1,0 +1,8 @@
+from .base import Airline
+
+
+class AirCanadaAirline(Airline):
+    pass
+
+
+AirCanada = AirCanadaAirline("Air Canada", ("AC", "KV", "QK", "RV", "ZX"))

--- a/ac_aqd/airlines/alliance.py
+++ b/ac_aqd/airlines/alliance.py
@@ -1,0 +1,5 @@
+from .base import Airline
+
+
+class StarAllianceAirline(Airline):
+    pass

--- a/ac_aqd/airlines/base.py
+++ b/ac_aqd/airlines/base.py
@@ -2,7 +2,7 @@ from ..aeroplan import AeroplanStatus, FareBrand
 from ..data import Airport
 
 
-class Carrier(object):
+class Airline(object):
 
     def __init__(
         self,

--- a/ac_aqd/airlines/partner.py
+++ b/ac_aqd/airlines/partner.py
@@ -1,0 +1,5 @@
+from .base import Airline
+
+
+class PartnerAirline(Airline):
+    pass

--- a/ac_aqd/carriers/__init__.py
+++ b/ac_aqd/carriers/__init__.py
@@ -1,8 +1,0 @@
-from .ac import AirCanada
-from .base import Carrier
-
-
-CARRIERS = (AirCanada,)
-
-
-DEFAULT_CARRIER, DEFAULT_CARRIER_INDEX = AirCanada, 0

--- a/ac_aqd/carriers/ac.py
+++ b/ac_aqd/carriers/ac.py
@@ -1,8 +1,0 @@
-from .base import Carrier
-
-
-class AirCanadaCarrier(Carrier):
-    pass
-
-
-AirCanada = AirCanadaCarrier("Air Canada", ("AC", "KV", "QK", "RV", "ZX"))

--- a/ac_aqd/carriers/alliance.py
+++ b/ac_aqd/carriers/alliance.py
@@ -1,5 +1,0 @@
-from .base import Carrier
-
-
-class StarAllianceCarrier(Carrier):
-    pass

--- a/ac_aqd/carriers/partner.py
+++ b/ac_aqd/carriers/partner.py
@@ -1,5 +1,0 @@
-from .base import Carrier
-
-
-class PartnerCarrier(Carrier):
-    pass

--- a/ac_aqd/itinerary.py
+++ b/ac_aqd/itinerary.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass, field
 
 from .aeroplan import FareBrand, DEFAULT_FARE_BRAND, DEFAULT_FARE_CLASS
-from .carriers import Carrier, DEFAULT_CARRIER
+from .airlines import Airline, DEFAULT_AIRLINE
 from .data import Airport, DEFAULT_ORIGIN_AIRPORT, DEFAULT_DESTINATION_AIRPORT
 
 
 @dataclass
 class Segment:
-    airline: Carrier = DEFAULT_CARRIER
+    airline: Airline = DEFAULT_AIRLINE
     origin: Airport = DEFAULT_ORIGIN_AIRPORT
     destination: Airport = DEFAULT_DESTINATION_AIRPORT
     fare_brand: FareBrand = DEFAULT_FARE_BRAND

--- a/apps/ac-aqd.py
+++ b/apps/ac-aqd.py
@@ -2,7 +2,7 @@ import pandas as pd
 import streamlit as st
 
 from ac_aqd.aeroplan import AEROPLAN_STATUSES, FARE_BRANDS
-from ac_aqd.carriers import CARRIERS, DEFAULT_CARRIER_INDEX
+from ac_aqd.airlines import AIRLINES, DEFAULT_AIRLINE_INDEX
 from ac_aqd.data import AIRPORTS, COUNTRIES, DISTANCES, DEFAULT_ORIGIN_AIRPORT_INDEX
 from ac_aqd.itinerary import Itinerary, Segment
 
@@ -12,7 +12,7 @@ def main():
 
     tools = {
         "Calculate Miles and Dollars": calculate_miles_dollars,
-        "Browse Carriers": browse_carriers,
+        "Browse Airlines": browse_airlines,
         "Browse Distances": browse_distances,
     }
     tool_title = st.sidebar.radio("Tool", tools.keys())
@@ -54,11 +54,11 @@ def calculate_miles_dollars(title):
                 airline_col, origin_col, destination_col, fare_brand_col, fare_class_col = st.columns((3, 2, 2, 3, 1))
 
                 segment.airline = airline_col.selectbox(
-                    "Carrier ✈️",
-                    CARRIERS,
-                    index=CARRIERS.index(segment.airline),
-                    format_func=lambda carrier: carrier.name,
-                    help="Flight segment operating carrier.",
+                    "Airline ✈️",
+                    AIRLINES,
+                    index=AIRLINES.index(segment.airline),
+                    format_func=lambda airline: airline.name,
+                    help="Flight segment operating airline.",
                     key=f"airline-{index}",
                 )
                 segment.origin = origin_col.selectbox(
@@ -93,19 +93,19 @@ def calculate_miles_dollars(title):
                 )
 
 
-def browse_carriers(title):
+def browse_airlines(title):
     st.header(title)
 
-    carrier = st.selectbox(
-        "Carrier ✈️",
-        CARRIERS,
-        index=DEFAULT_CARRIER_INDEX,
-        format_func=lambda carrier: carrier.name,
-        help="Operating carrier.",
+    airline = st.selectbox(
+        "Airline ✈️",
+        AIRLINES,
+        index=DEFAULT_AIRLINE_INDEX,
+        format_func=lambda airline: airline.name,
+        help="Operating airline.",
     )
 
-    st.subheader(carrier.name)
-    st.text(", ".join(carrier.codes))
+    st.subheader(airline.name)
+    st.text(", ".join(airline.codes))
 
 
 def browse_distances(title):


### PR DESCRIPTION
Airline seems to be the more common terminology, at least on Air
Canada's website. Change all mentions of "carrier" to "airline".